### PR TITLE
skip spamming all players when Perun doesn't run

### DIFF
--- a/01_DCS/Mods/services/Perun/lua/perun_config.lua
+++ b/01_DCS/Mods/services/Perun/lua/perun_config.lua
@@ -16,6 +16,9 @@ PerunConfig.MOTD_L1 = "[Perun] Welcome to our server !"											-- (string) Me
 PerunConfig.MOTD_L2 = "[Perun] Stats and event data integrated with Perun for DCS World"		-- (string) Message send to players connecting the server - Line 2
 PerunConfig.ConnectionError_L1 = "[Perun] ERROR: Connection broken - contact server admin!"     -- (string) Information to send to players when Perun connection is broken
 
+-- Misc
+PerunConfig.DontSpamPlayersInCaseOfError = false  -- don't spam the game chat with error messages if the connection to Perun does not work
+
 -- Debug
 PerunConfig.DebugMode = 1																		-- (int) [0 (default),1,2] Value greater than 0 will display Perun information in DCS log file, values: 1 - minimal verbose, 2 - all log information will be logged
 

--- a/01_DCS/Scripts/Hooks/Perun-hook.lua
+++ b/01_DCS/Scripts/Hooks/Perun-hook.lua
@@ -23,6 +23,7 @@ Perun.DebugMode = PerunConfig.DebugMode
 Perun.MOTD_L1 = PerunConfig.MOTD_L1
 Perun.MOTD_L2 = PerunConfig.MOTD_L2
 Perun.ConnectionError = PerunConfig.ConnectionError_L1
+Perun.DontSpamPlayersInCaseOfError = PerunConfig.DontSpamPlayersInCaseOfError
 
 -- Variable init
 Perun.Version = "v0.12.0"
@@ -262,12 +263,15 @@ Perun.SendToPerun = function(data_id, data_package)
 	-- Add information to log file and send chat message to all that Perun connection is broken
 		-- Add information to log file	
 		Perun.AddLog("ERROR - TCP connection is not available",0)
-		
+
 		-- Informs all players that there is Peron error; below hack for DCS net.send_chat not working
-		local _all_players = net.get_player_list()
-		for PlayerIDIndex, _playerID in ipairs(_all_players) do
-			net.send_chat_to(Perun.ConnectionError , _playerID)
+		if not Perun.DontSpamPlayersInCaseOfError then
+			local _all_players = net.get_player_list()
+			for PlayerIDIndex, _playerID in ipairs(_all_players) do
+				net.send_chat_to(Perun.ConnectionError , _playerID)
+			end
 		end
+		
 		-- Reset last error send counter
 		Perun.lastConnectionError = _now
 	end 


### PR DESCRIPTION
I added a config option (DontSpamPlayersInCaseOfError) that, if true, will skip sending messages every minute to every player, when Perun socket cannot be connected.